### PR TITLE
Php 7.3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=8.1",
+        "php": ">=7.3",
         "aws/aws-sdk-php": "^3.1",
-        "illuminate/container": "~9|~10|~11",
-        "illuminate/contracts": "~9|~10|~11",
-        "illuminate/filesystem": "~9|~10|~11",
-        "illuminate/queue": "~9|~10|~11",
-        "illuminate/support": "~9|~10|~11"
+        "illuminate/container": "^8.0|~9|~10|~11",
+        "illuminate/contracts": "^8.0|~9|~10|~11",
+        "illuminate/filesystem": "^8.0|~9|~10|~11",
+        "illuminate/queue": "^8.0|~9|~10|~11",
+        "illuminate/support": "^8.0|~9|~10|~11"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     "require": {
         "php": ">=7.3",
         "aws/aws-sdk-php": "^3.1",
-        "illuminate/container": "^8.0|~9|~10|~11",
-        "illuminate/contracts": "^8.0|~9|~10|~11",
-        "illuminate/filesystem": "^8.0|~9|~10|~11",
-        "illuminate/queue": "^8.0|~9|~10|~11",
-        "illuminate/support": "^8.0|~9|~10|~11"
+        "illuminate/container": "^7.0|^8.0|~9|~10|~11",
+        "illuminate/contracts": "^7.0|^8.0|~9|~10|~11",
+        "illuminate/filesystem": "^7.0|^8.0|~9|~10|~11",
+        "illuminate/queue": "^7.0|^8.0|~9|~10|~11",
+        "illuminate/support": "^7.0|^8.0|~9|~10|~11"
     }
 }

--- a/src/Providers/SqsWithS3ServiceProvider.php
+++ b/src/Providers/SqsWithS3ServiceProvider.php
@@ -13,6 +13,8 @@ class SqsWithS3ServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $manager = $this->app->make('queue');
-        $manager->addConnector('sqs-with-s3', fn () => new SqsWithS3Connector());
+        $manager->addConnector('sqs-with-s3', function () {
+            return new SqsWithS3Connector();
+        });
     }
 }

--- a/src/Queue/SqsWithS3Queue.php
+++ b/src/Queue/SqsWithS3Queue.php
@@ -24,8 +24,10 @@ class SqsWithS3Queue extends SqsQueue
 
     /**
      * The storage options to save large payloads.
+     *
+     * @var array
      */
-    protected array $s3Options;
+    protected $s3Options;
 
     /**
      * Create a new Amazon SQS queue instance.
@@ -43,7 +45,7 @@ class SqsWithS3Queue extends SqsQueue
         $s3Options,
         $prefix = '',
         $suffix = '',
-        $dispatchAfterCommit = false,
+        $dispatchAfterCommit = false
     ) {
         $this->s3Options = $s3Options;
 

--- a/src/Traits/SqsWithS3BaseJob.php
+++ b/src/Traits/SqsWithS3BaseJob.php
@@ -28,13 +28,17 @@ trait SqsWithS3BaseJob
     /**
      * Holds the raw body to prevent fetching the file from
      * s3 multiple times.
+     *
+     * @var string
      */
-    protected string $cachedRawBody = '';
+    protected $cachedRawBody = '';
 
     /**
      * s3 options for the job.
+     *
+     * @var array
      */
-    protected array $s3Options;
+    protected $s3Options;
 
     /**
      * Create a new job instance.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Extended PHP version support from 7.3+ (previously 8.1+), enabling compatibility with legacy systems.
* Expanded Laravel Illuminate package support to include v7 and v8 releases alongside existing v9, v10, and v11 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->