### PR TITLE
Php 7.3 with fifo support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=8.1",
+        "php": ">=7.3",
         "aws/aws-sdk-php": "^3.1",
-        "illuminate/container": "~9|~10|~11",
-        "illuminate/contracts": "~9|~10|~11",
-        "illuminate/filesystem": "~9|~10|~11",
-        "illuminate/queue": "~9|~10|~11",
-        "illuminate/support": "~9|~10|~11"
+        "illuminate/container": "^8.0|~9|~10|~11",
+        "illuminate/contracts": "^8.0|~9|~10|~11",
+        "illuminate/filesystem": "^8.0|~9|~10|~11",
+        "illuminate/queue": "^8.0|~9|~10|~11",
+        "illuminate/support": "^8.0|~9|~10|~11"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     "require": {
         "php": ">=7.3",
         "aws/aws-sdk-php": "^3.1",
-        "illuminate/container": "^8.0|~9|~10|~11",
-        "illuminate/contracts": "^8.0|~9|~10|~11",
-        "illuminate/filesystem": "^8.0|~9|~10|~11",
-        "illuminate/queue": "^8.0|~9|~10|~11",
-        "illuminate/support": "^8.0|~9|~10|~11"
+        "illuminate/container": "^7.0|^8.0|~9|~10|~11",
+        "illuminate/contracts": "^7.0|^8.0|~9|~10|~11",
+        "illuminate/filesystem": "^7.0|^8.0|~9|~10|~11",
+        "illuminate/queue": "^7.0|^8.0|~9|~10|~11",
+        "illuminate/support": "^7.0|^8.0|~9|~10|~11"
     }
 }

--- a/src/Contracts/FifoMessage.php
+++ b/src/Contracts/FifoMessage.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SqsWithS3\Contracts;
+
+/**
+ * Implement this contract on a queued Job to dispatch it onto a FIFO SQS queue
+ * with a deterministic MessageGroupId and MessageDeduplicationId.
+ *
+ * - MessageGroupId: required by FIFO. Messages with the same group are processed in order.
+ *   For workloads where ordering is not required, you can return any stable identifier
+ *   that partitions traffic for throughput (e.g. accountId).
+ *
+ * - MessageDeduplicationId: required by FIFO when content-based dedup is not enabled.
+ *   Should be a deterministic hash of the logical message (e.g. sha256 of payload +
+ *   identifying keys) so that retries/duplicates produce the same id within the 5-min
+ *   SQS dedup window.
+ */
+interface FifoMessage
+{
+    public function getMessageGroupId(): string;
+
+    public function getMessageDeduplicationId(): string;
+}

--- a/src/Providers/SqsWithS3ServiceProvider.php
+++ b/src/Providers/SqsWithS3ServiceProvider.php
@@ -13,6 +13,8 @@ class SqsWithS3ServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $manager = $this->app->make('queue');
-        $manager->addConnector('sqs-with-s3', fn () => new SqsWithS3Connector());
+        $manager->addConnector('sqs-with-s3', function () {
+            return new SqsWithS3Connector();
+        });
     }
 }

--- a/src/Queue/Connectors/SqsWithS3Connector.php
+++ b/src/Queue/Connectors/SqsWithS3Connector.php
@@ -33,6 +33,7 @@ class SqsWithS3Connector extends SqsConnector implements ConnectorInterface
             $config['prefix'] ?? '',
             $config['suffix'] ?? '',
             $config['after_commit'] ?? null,
+            (int) ($config['visibility_timeout'] ?? 0),
         );
     }
 }

--- a/src/Queue/SqsWithS3Queue.php
+++ b/src/Queue/SqsWithS3Queue.php
@@ -49,33 +49,31 @@ class SqsWithS3Queue extends SqsQueue
      *
      * Overridden so that jobs implementing {@see FifoMessage} can attach
      * MessageGroupId / MessageDeduplicationId to the SQS send call.
+     *
+     * Matches Laravel 7's SqsQueue::push() signature exactly — do not use
+     * enqueueUsing() here (that helper was introduced in Laravel 8).
      */
     public function push($job, $data = '', $queue = null)
     {
-        return $this->enqueueUsing(
-            $job,
+        return $this->pushRaw(
             $this->createPayload($job, $queue ?: $this->default, $data),
             $queue,
-            null,
-            function ($payload, $queue) use ($job) {
-                return $this->pushRaw($payload, $queue, $this->fifoOptions($job));
-            }
+            $this->fifoOptions($job)
         );
     }
 
     /**
      * Push a new job onto the queue after a delay.
+     *
+     * Matches Laravel 7's SqsQueue::later() signature exactly.
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        return $this->enqueueUsing(
-            $job,
+        return $this->pushRaw(
             $this->createPayload($job, $queue ?: $this->default, $data),
             $queue,
-            $delay,
-            function ($payload, $queue) use ($job, $delay) {
-                return $this->pushRaw($payload, $queue, $this->fifoOptions($job), $delay);
-            }
+            $this->fifoOptions($job),
+            $delay
         );
     }
 

--- a/src/Queue/SqsWithS3Queue.php
+++ b/src/Queue/SqsWithS3Queue.php
@@ -31,15 +31,23 @@ class SqsWithS3Queue extends SqsQueue
      */
     protected $s3Options;
 
+    /**
+     * Per-receive VisibilityTimeout override (seconds).
+     * 0 means "use the queue's default."
+     */
+    protected int $visibilityTimeout = 0;
+
     public function __construct(
         SqsClient $sqs,
         $default,
         $s3Options,
         $prefix = '',
         $suffix = '',
-        $dispatchAfterCommit = false
+        $dispatchAfterCommit = false,
+        int $visibilityTimeout = 0
     ) {
         $this->s3Options = $s3Options;
+        $this->visibilityTimeout = $visibilityTimeout;
 
         parent::__construct($sqs, $default, $prefix, $suffix, $dispatchAfterCommit);
     }
@@ -130,10 +138,16 @@ class SqsWithS3Queue extends SqsQueue
      */
     public function pop($queue = null)
     {
-        $response = $this->sqs->receiveMessage([
-            'QueueUrl' => $queue = $this->getQueue($queue),
+        $params = [
+            'QueueUrl'       => $queue = $this->getQueue($queue),
             'AttributeNames' => ['ApproximateReceiveCount'],
-        ]);
+        ];
+
+        if ($this->visibilityTimeout > 0) {
+            $params['VisibilityTimeout'] = $this->visibilityTimeout;
+        }
+
+        $response = $this->sqs->receiveMessage($params);
 
         if (!is_null($response['Messages']) && count($response['Messages']) > 0) {
             return new SqsWithS3Job(

--- a/src/Queue/SqsWithS3Queue.php
+++ b/src/Queue/SqsWithS3Queue.php
@@ -34,8 +34,13 @@ class SqsWithS3Queue extends SqsQueue
     /**
      * Per-receive VisibilityTimeout override (seconds).
      * 0 means "use the queue's default."
+     *
+     * Typed-property syntax (`protected int $foo`) is PHP 7.4+, this branch
+     * targets PHP 7.3 — keep this as a plain property with a phpdoc type.
+     *
+     * @var int
      */
-    protected int $visibilityTimeout = 0;
+    protected $visibilityTimeout = 0;
 
     public function __construct(
         SqsClient $sqs,

--- a/src/Queue/SqsWithS3Queue.php
+++ b/src/Queue/SqsWithS3Queue.php
@@ -6,10 +6,12 @@ use DateInterval;
 use Aws\Sqs\SqsClient;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Contracts\Queue\Job;
 use SqsWithS3\Traits\PayloadPointers;
 use SqsWithS3\Jobs\SqsWithS3Job;
+use SqsWithS3\Contracts\FifoMessage;
 
 class SqsWithS3Queue extends SqsQueue
 {
@@ -29,16 +31,6 @@ class SqsWithS3Queue extends SqsQueue
      */
     protected $s3Options;
 
-    /**
-     * Create a new Amazon SQS queue instance.
-     *
-     * @param  string  $default
-     * @param  array  $s3Options
-     * @param  string  $prefix
-     * @param  string  $suffix
-     * @param  bool  $dispatchAfterCommit
-     * @return void
-     */
     public function __construct(
         SqsClient $sqs,
         $default,
@@ -53,17 +45,55 @@ class SqsWithS3Queue extends SqsQueue
     }
 
     /**
+     * Push a new job onto the queue.
+     *
+     * Overridden so that jobs implementing {@see FifoMessage} can attach
+     * MessageGroupId / MessageDeduplicationId to the SQS send call.
+     */
+    public function push($job, $data = '', $queue = null)
+    {
+        return $this->enqueueUsing(
+            $job,
+            $this->createPayload($job, $queue ?: $this->default, $data),
+            $queue,
+            null,
+            function ($payload, $queue) use ($job) {
+                return $this->pushRaw($payload, $queue, $this->fifoOptions($job));
+            }
+        );
+    }
+
+    /**
+     * Push a new job onto the queue after a delay.
+     */
+    public function later($delay, $job, $data = '', $queue = null)
+    {
+        return $this->enqueueUsing(
+            $job,
+            $this->createPayload($job, $queue ?: $this->default, $data),
+            $queue,
+            $delay,
+            function ($payload, $queue) use ($job, $delay) {
+                return $this->pushRaw($payload, $queue, $this->fifoOptions($job), $delay);
+            }
+        );
+    }
+
+    /**
      * Push a raw payload onto the queue.
      *
      * @param  string  $payload
      * @param  string|null  $queue
+     * @param  array  $options   Supports MessageGroupId and MessageDeduplicationId for FIFO queues.
      * @param  mixed  $delay
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [], $delay = 0)
     {
+        $queueUrl = $this->getQueue($queue);
+
         $message = [
-            'QueueUrl' => $this->getQueue($queue),
+            'QueueUrl' => $queueUrl,
             'MessageBody' => $payload,
         ];
 
@@ -75,6 +105,21 @@ class SqsWithS3Queue extends SqsQueue
             $message['MessageBody'] = json_encode(['pointer' => $filepath]);
         }
 
+        // FIFO queues require MessageGroupId. When a job implements FifoMessage the caller
+        // will pass the ids through $options. If the queue is FIFO but no group id was
+        // supplied, fall back to a safe default so the send does not fail.
+        if ($this->isFifoQueue($queueUrl)) {
+            $message['MessageGroupId'] = $options['MessageGroupId']
+                ?? Arr::get($this->s3Options, 'default_message_group_id', 'default');
+
+            if (!empty($options['MessageDeduplicationId'])) {
+                $message['MessageDeduplicationId'] = $options['MessageDeduplicationId'];
+            }
+
+            // FIFO queues do not support per-message DelaySeconds.
+            $delay = 0;
+        }
+
         if ($delay) {
             $message['DelaySeconds'] = $this->secondsUntil($delay);
         }
@@ -83,32 +128,7 @@ class SqsWithS3Queue extends SqsQueue
     }
 
     /**
-     * Push a new job onto the queue after a delay.
-     *
-     * @param  DateTimeInterface|DateInterval|int  $delay
-     * @param  string  $job
-     * @param  mixed  $data
-     * @param  string|null  $queue
-     * @return mixed
-     */
-    public function later($delay, $job, $data = '', $queue = null)
-    {
-        return $this->enqueueUsing(
-            $job,
-            $this->createPayload($job, $queue ?: $this->default, $data),
-            $queue,
-            $delay,
-            function ($payload, $queue) use ($delay) {
-                return $this->pushRaw($payload, $queue, [], $delay);
-            }
-        );
-    }
-
-    /**
      * Pop the next job off of the queue.
-     *
-     * @param  string|null  $queue
-     * @return Job|null
      */
     public function pop($queue = null)
     {
@@ -131,9 +151,6 @@ class SqsWithS3Queue extends SqsQueue
 
     /**
      * Delete all the jobs from the queue.
-     *
-     * @param  string  $queue
-     * @return int
      */
     public function clear($queue)
     {
@@ -142,5 +159,28 @@ class SqsWithS3Queue extends SqsQueue
                 $this->getConfiguredStorage()->deleteDirectory("queue-payloads");
             }
         });
+    }
+
+    /**
+     * Extract FIFO options from a dispatched job, when the job implements FifoMessage.
+     */
+    protected function fifoOptions($job): array
+    {
+        if (!is_object($job) || !($job instanceof FifoMessage)) {
+            return [];
+        }
+
+        return [
+            'MessageGroupId' => $job->getMessageGroupId(),
+            'MessageDeduplicationId' => $job->getMessageDeduplicationId(),
+        ];
+    }
+
+    /**
+     * FIFO queue URLs always end with `.fifo`.
+     */
+    protected function isFifoQueue(string $queueUrl): bool
+    {
+        return Str::endsWith($queueUrl, '.fifo');
     }
 }

--- a/src/Queue/SqsWithS3Queue.php
+++ b/src/Queue/SqsWithS3Queue.php
@@ -24,8 +24,10 @@ class SqsWithS3Queue extends SqsQueue
 
     /**
      * The storage options to save large payloads.
+     *
+     * @var array
      */
-    protected array $s3Options;
+    protected $s3Options;
 
     /**
      * Create a new Amazon SQS queue instance.
@@ -43,7 +45,7 @@ class SqsWithS3Queue extends SqsQueue
         $s3Options,
         $prefix = '',
         $suffix = '',
-        $dispatchAfterCommit = false,
+        $dispatchAfterCommit = false
     ) {
         $this->s3Options = $s3Options;
 

--- a/src/Traits/SqsWithS3BaseJob.php
+++ b/src/Traits/SqsWithS3BaseJob.php
@@ -28,13 +28,17 @@ trait SqsWithS3BaseJob
     /**
      * Holds the raw body to prevent fetching the file from
      * s3 multiple times.
+     *
+     * @var string
      */
-    protected string $cachedRawBody = '';
+    protected $cachedRawBody = '';
 
     /**
      * s3 options for the job.
+     *
+     * @var array
      */
-    protected array $s3Options;
+    protected $s3Options;
 
     /**
      * Create a new job instance.

--- a/src/Traits/SqsWithS3BaseJob.php
+++ b/src/Traits/SqsWithS3BaseJob.php
@@ -58,6 +58,19 @@ trait SqsWithS3BaseJob
     }
 
     /**
+     * Release the job back onto the queue.
+     *
+     * Casts $delay to int before delegating to SqsJob::release(), which passes
+     * the value directly to changeMessageVisibility as VisibilityTimeout. The
+     * AWS SDK requires an integer; the Laravel worker passes $options->delay as
+     * a string (e.g. '0') causing an ErrorException without this cast.
+     */
+    public function release($delay = 0): void
+    {
+        parent::release((int) $delay);
+    }
+
+    /**
      * Delete the job from the queue.
      */
     public function delete(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FIFO SQS support with message grouping and deduplication; optional per-receive visibility timeout control.
  * Ensures FIFO queues disable per-message delays and honor FIFO semantics.

* **Bug Fixes / Improvements**
  * Improved job release/delay handling to enforce integer delays for SQS compatibility.

* **Chores**
  * Broadened platform compatibility to PHP 7.3+ and Laravel 7.x–11.x.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->