### PR TITLE
ACC-1521 : Implement multi region queue for Note Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Add below configurations in queue.php :
         'always_store' => false,
         'cleanup' => true,
         'disk' => 's3',
-        'prefix' => env('SQS_QUEUE', 'your-queue-name')
+        'prefix' => env('SQS_QUEUE', 'your-queue-name'),
+        'mr_enabled' => false
     ],
 ],
 ```

--- a/src/Queue/SqsWithS3Queue.php
+++ b/src/Queue/SqsWithS3Queue.php
@@ -67,7 +67,12 @@ class SqsWithS3Queue extends SqsQueue
 
         if (strlen($payload) >= self::MAX_SQS_LENGTH || Arr::get($this->s3Options, 'always_store')) {
             $uuid = json_decode($payload)->uuid;
+            $enabledMR = Arr::get($this->s3Options, 'mr_enabled');
+
             $filepath = "queue-payloads/" . "{$uuid}.json";
+            if($enabledMR === true) {
+                $filepath =  env('SQS_MR_REGION') . "-queue-payloads/" . "{$uuid}.json";
+            }
             $this->getConfiguredStorage()->put($filepath, $payload);
 
             $message['MessageBody'] = json_encode(['pointer' => $filepath]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Configuration example updated to include the `mr_enabled` option for queue payload settings.

* **New Features**
  * S3 queue payloads now optionally support regional path prefixing when the corresponding configuration option is enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Workforce-Cloud-Tech/sqs-with-s3/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->